### PR TITLE
Look for default config file in UserConfigDir

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -88,6 +89,43 @@ func init() {
 }
 
 func main() {
+	// Load config file first, so that any additional flags will take priority
+	if configFile == "" {
+		// config file not provided -- look for default file
+		if path, err := os.UserConfigDir(); err == nil {
+			path = filepath.Join(path, "mail2go", "mail2go.conf")
+			if _, err := os.Stat(path); err == nil {
+				configFile = path
+			}
+		}
+	}
+	if configFile != "" {
+		config, err := loadConfig(configFile)
+		if err != nil {
+			fmt.Printf("Error loading config file: %v", err)
+		}
+
+		// Override flags with config file values if set
+		if config.SMTPServer != "" {
+			smtpServer = config.SMTPServer
+		}
+		if config.SMTPPort != 0 {
+			smtpPort = config.SMTPPort
+		}
+		if config.SMTPUsername != "" {
+			username = config.SMTPUsername
+		}
+		if config.SMTPPassword != "" {
+			password = config.SMTPPassword
+		}
+		if config.TLSMode != "" {
+			tlsMode = config.TLSMode
+		}
+		if config.FromEmail != "" {
+			fromEmail = config.FromEmail
+		}
+	}
+
 	// Override the default flag.Usage
 	flag.Usage = Usage
 	flag.Parse()
@@ -128,34 +166,6 @@ func main() {
 	}
 	if bodyFileShort != "" {
 		bodyFile = bodyFileShort
-	}
-
-	// Load config from file if provided
-	if configFile != "" {
-		config, err := loadConfig(configFile)
-		if err != nil {
-			fmt.Printf("Error loading config file: %v", err)
-		}
-
-		// Override flags with config file values if set
-		if config.SMTPServer != "" {
-			smtpServer = config.SMTPServer
-		}
-		if config.SMTPPort != 0 {
-			smtpPort = config.SMTPPort
-		}
-		if config.SMTPUsername != "" {
-			username = config.SMTPUsername
-		}
-		if config.SMTPPassword != "" {
-			password = config.SMTPPassword
-		}
-		if config.TLSMode != "" {
-			tlsMode = config.TLSMode
-		}
-		if config.FromEmail != "" {
-			fromEmail = config.FromEmail
-		}
 	}
 
 	// Check if required flags or config values are missing


### PR DESCRIPTION
Every platform has a standard location for config files, so we might as well look there for one.  This makes scripts which use mail2go simpler and more portable.

Additionally, we now parse the config file *first*, so that any provided flags will override what's in the (possibly default) config file.